### PR TITLE
refactor: remove legacy root option

### DIFF
--- a/src/__tests__/renderer.test.tsx
+++ b/src/__tests__/renderer.test.tsx
@@ -29,24 +29,6 @@ test("basic renderer usage", () => {
 `);
 });
 
-test("renderer supports legacyRoot: true option", () => {
-  const renderer = renderWithAct(<div>Hello!</div>, { legacyRoot: true });
-  expect(renderer.root?.toJSON()).toMatchInlineSnapshot(`
-<div>
-  Hello!
-</div>
-`);
-});
-
-test("renderer supports legacyRoot: false  option", () => {
-  const renderer = renderWithAct(<div>Hello!</div>, { legacyRoot: false });
-  expect(renderer.root?.toJSON()).toMatchInlineSnapshot(`
-<div>
-  Hello!
-</div>
-`);
-});
-
 test("render with single allowed text component", () => {
   let renderer = renderWithAct(createElement("Text", null, "Hello!"), {
     textComponents: ["Text"],

--- a/src/platforms/react-native.ts
+++ b/src/platforms/react-native.ts
@@ -2,13 +2,11 @@ import { ReactElement } from "react";
 import { createRoot, Root } from "../renderer";
 
 export type ReactNativeRootOptions = {
-  legacyRoot?: boolean;
   createNodeMock?: (element: ReactElement) => object;
 };
 
 const createReactNativeRoot = (options?: ReactNativeRootOptions): Root => {
   return createRoot({
-    legacyRoot: options?.legacyRoot,
     createNodeMock: options?.createNodeMock,
     textComponents: ["Text", "RCTText"],
   });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -2,7 +2,7 @@ import { ReactElement } from "react";
 import { Container, TestReconciler } from "./reconciler";
 import { HostElement } from "./host-element";
 import { FiberRoot } from "react-reconciler";
-import { ConcurrentRoot, LegacyRoot } from "react-reconciler/constants";
+import { ConcurrentRoot } from "react-reconciler/constants";
 
 // Refs:
 // https://github.com/facebook/react/blob/v18.3.1/packages/react-noop-renderer/src/createReactNoop.js
@@ -10,7 +10,6 @@ import { ConcurrentRoot, LegacyRoot } from "react-reconciler/constants";
 // https://github.com/facebook/react/blob/v18.3.1/packages/react-native-renderer/src/ReactFabricHostConfig.js
 
 export type RootOptions = {
-  legacyRoot?: boolean;
   textComponents?: string[];
   createNodeMock?: (element: ReactElement) => object;
 };
@@ -36,7 +35,7 @@ export function createRoot(options?: RootOptions): Root {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   let containerFiber: FiberRoot = TestReconciler.createContainer(
     container,
-    options?.legacyRoot ? LegacyRoot : ConcurrentRoot,
+    ConcurrentRoot,
     null, // hydration callbacks
     false, // isStrictMode
     null, // concurrentUpdatesByDefaultOverride


### PR DESCRIPTION
### Summary

Remove `legacyRoot` option as no longer relevant for React 19 rendering.

### Testing

Adjusted automated tests.