### PR TITLE
chore: react@next CI checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        react-version: ["^19.0.0", "^19.1.0", "^19.2.0", "latest", "next"]
+        react-version: ["^19.0.0", "^19.1.0", "^19.2.0", "latest"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   validate:
     name: Validate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         run: bun run test:ci
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,3 +56,24 @@ jobs:
 
       - name: Run tests
         run: bun run test:ci
+
+  test-canary-react:
+    name: Test React Canary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup deps
+        uses: ./.github/actions/setup
+
+      - name: Install React canary
+        run: bun add -d react@next
+
+      - name: Install react-reconciler canary
+        run: bun add react-reconciler@next
+
+      - name: Build with canary dependencies
+        run: bun run build
+
+      - name: Run tests with canary dependencies
+        run: bun run test:ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        react-version: ["^19.0.0", "^19.1.0", "^19.2.0", "latest"]
+        react-version: ["~19.0.0", "~19.1.0", "~19.2.0", "latest"]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,24 +59,3 @@ jobs:
 
       - name: Run tests
         run: bun run test:ci
-
-  test-canary-react:
-    name: Test React canary
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup deps
-        uses: ./.github/actions/setup
-
-      - name: Install React canary
-        run: bun add -d react@next
-
-      - name: Install react-reconciler canary
-        run: bun add react-reconciler@next
-
-      - name: Build with canary dependencies
-        run: bun run build
-
-      - name: Run tests with canary dependencies
-        run: bun run test:ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
         run: bun run test:ci
 
   test-canary-react:
-    name: Test React Canary
+    name: Test React canary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,8 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Run prettier
-        run: bun run prettier
+      - name: Run format
+        run: bun run format:check
 
       - name: Run linter
         run: bun run lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup deps
         uses: ./.github/actions/setup
@@ -43,7 +43,7 @@ jobs:
       matrix:
         react-version: ["^19.0.0", "^19.1.0", "^19.2.0", "latest"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup deps
         uses: ./.github/actions/setup
@@ -61,7 +61,7 @@ jobs:
     name: Test React Canary
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup deps
         uses: ./.github/actions/setup

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   test-react-versions:
     name: Test React ${{ matrix.react-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,7 +5,22 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
+  react-release-guard:
+    name: Guard React Latest Support Window
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup deps
+        uses: ./.github/actions/setup
+
+      - name: Check latest React release against supported line
+        run: bun run check:react-release-guard
+
   test-react-versions:
     name: Test React ${{ matrix.react-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -28,7 +28,7 @@ jobs:
         run: bun run test:ci
 
   test-canary-react:
-    name: Test React Canary
+    name: Test React canary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        react-version: ["^19.0.0", "^19.1.0", "^19.2.0", "latest"]
+        react-version: ["~19.0.0", "~19.1.0", "~19.2.0", "latest"]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         react-version: ["^19.0.0", "^19.1.0", "^19.2.0", "latest"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup deps
         uses: ./.github/actions/setup
@@ -31,7 +31,7 @@ jobs:
     name: Test React Canary
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup deps
         uses: ./.github/actions/setup

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -6,12 +6,13 @@ on:
   workflow_dispatch:
 
 jobs:
+
   test-react-versions:
     name: Test React ${{ matrix.react-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        react-version: ["^19.0.0", "^19.1.0", "^19.2.0", "latest", "next"]
+        react-version: ["^19.0.0", "^19.1.0", "^19.2.0", "latest"]
     steps:
       - uses: actions/checkout@v4
 
@@ -25,4 +26,25 @@ jobs:
         run: bun run typecheck
 
       - name: Run tests
+        run: bun run test:ci
+
+  test-canary-react:
+    name: Test React Canary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup deps
+        uses: ./.github/actions/setup
+
+      - name: Install React canary
+        run: bun add -d react@next
+
+      - name: Install react-reconciler canary
+        run: bun add react-reconciler@next
+
+      - name: Build with canary dependencies
+        run: bun run build
+
+      - name: Run tests with canary dependencies
         run: bun run test:ci

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,9 @@ Project docs:
 - [Development Conventions](./docs/agents/development-conventions.md)
 - [Commands](./docs/agents/commands.md)
 - [Versioning](./docs/versioning.md)
+
+PR draft workflow:
+
+- Maintain `PR.txt` at the repository root using the structure from `.github/pull_request_template.md`.
+- Keep `PR.txt` aligned with the current branch diff relative to `origin/main`, including tests actually run and any known validation gaps.
+- Do not commit `PR.txt`.

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -8,7 +8,7 @@ Use Bun to run repository scripts.
 - `bun run test` runs the Jest test suite.
 - `bun run test:ci` runs tests with coverage.
 - `bun run lint` runs ESLint.
-- `bun run prettier` checks formatting.
-- `bun run prettier:fix` writes formatting changes.
+- `bun run format` checks formatting.
+- `bun run format:fix` writes formatting changes.
 - `bun run validate` runs typecheck, test, lint, and formatting checks.
 - `bun run validate:fix` runs formatting and lint fixes, then typecheck and tests.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,17 @@ export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.strictTypeChecked,
   {
+    files: ["**/*.{js,mjs,cjs}"],
+    ...tseslint.configs.disableTypeChecked,
+    languageOptions: {
+      globals: {
+        console: "readonly",
+        fetch: "readonly",
+        process: "readonly",
+      },
+    },
+  },
+  {
     files: ["src/**/*.{ts,tsx}"],
     languageOptions: {
       parserOptions: {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test:watch": "jest --watch",
-    "validate": "bun run typecheck && bun run test && bun run lint && bun run format",
+    "validate": "bun run typecheck && bun run test && bun run lint && bun run format:check",
     "validate:fix": "bun run format:fix && bun run lint --fix && bun run typecheck && bun run test -u",
-    "format": "prettier --check .",
+    "format:check": "prettier --check .",
     "format:fix": "prettier --write .",
     "release": "release-it"
   },

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test:watch": "jest --watch",
-    "validate": "bun run typecheck && bun run test && bun run lint && bun run prettier",
-    "validate:fix": "bun run prettier:fix && bun run lint --fix && bun run typecheck && bun run test -u",
-    "prettier": "prettier --check .",
-    "prettier:fix": "prettier --write .",
+    "validate": "bun run typecheck && bun run test && bun run lint && bun run format",
+    "validate:fix": "bun run format:fix && bun run lint --fix && bun run typecheck && bun run test -u",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
     "release": "release-it"
   },
   "dependencies": {
@@ -55,6 +55,9 @@
   },
   "peerDependencies": {
     "react": "^19.0.0"
+  },
+  "testRenderer": {
+    "supportedReactRange": ">=19.0.0 <19.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "check:react-release-guard": "node scripts/check-react-release-guard.mjs",
     "dev": "tsup --watch",
     "test": "jest",
     "test:ci": "jest --coverage",

--- a/scripts/check-react-release-guard.mjs
+++ b/scripts/check-react-release-guard.mjs
@@ -1,0 +1,155 @@
+import packageJson from "../package.json" with { type: "json" };
+
+function parseSemver(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+
+  if (!match) {
+    throw new Error(`Unsupported semver format: ${version}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function compareSemver(left, right) {
+  if (left.major !== right.major) {
+    return left.major - right.major;
+  }
+
+  if (left.minor !== right.minor) {
+    return left.minor - right.minor;
+  }
+
+  return left.patch - right.patch;
+}
+
+function incrementCaretUpperBound(version) {
+  if (version.major > 0) {
+    return {
+      major: version.major + 1,
+      minor: 0,
+      patch: 0,
+    };
+  }
+
+  return {
+    major: 0,
+    minor: version.minor + 1,
+    patch: 0,
+  };
+}
+
+function incrementTildeUpperBound(version) {
+  return {
+    major: version.major,
+    minor: version.minor + 1,
+    patch: 0,
+  };
+}
+
+function parseExclusiveUpperBounds(range) {
+  const upperBounds = [];
+  const lessThanMatches = range.matchAll(/<\s*(\d+\.\d+\.\d+(?:[-+][^\s|]+)?)/g);
+
+  for (const match of lessThanMatches) {
+    upperBounds.push(parseSemver(match[1]));
+  }
+
+  const caretMatches = range.matchAll(/\^(\d+\.\d+\.\d+(?:[-+][^\s|]+)?)/g);
+  for (const match of caretMatches) {
+    upperBounds.push(incrementCaretUpperBound(parseSemver(match[1])));
+  }
+
+  const tildeMatches = range.matchAll(/~(\d+\.\d+\.\d+(?:[-+][^\s|]+)?)/g);
+  for (const match of tildeMatches) {
+    upperBounds.push(incrementTildeUpperBound(parseSemver(match[1])));
+  }
+
+  return upperBounds;
+}
+
+function getReactSupportWindow(range) {
+  const upperBounds = parseExclusiveUpperBounds(range);
+
+  if (upperBounds.length === 0) {
+    throw new Error(
+      `Could not derive a supported React ceiling from peerDependencies.react: ${range}`,
+    );
+  }
+
+  return upperBounds.reduce((lowest, candidate) =>
+    compareSemver(candidate, lowest) < 0 ? candidate : lowest,
+  );
+}
+
+function formatSemver(version) {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+function getSupportedLineLabel(upperBound) {
+  if (upperBound.patch === 0 && upperBound.minor > 0) {
+    return `${upperBound.major}.${upperBound.minor - 1}.x`;
+  }
+
+  if (upperBound.minor === 0 && upperBound.patch === 0) {
+    return `${upperBound.major - 1}.x`;
+  }
+
+  return `<${formatSemver(upperBound)}`;
+}
+
+async function getLatestReactVersion() {
+  const overriddenVersion = process.env.REACT_RELEASE_GUARD_LATEST;
+
+  if (overriddenVersion) {
+    return overriddenVersion;
+  }
+
+  const response = await fetch("https://registry.npmjs.org/react");
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch react package metadata: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const metadata = await response.json();
+  const latestVersion = metadata?.["dist-tags"]?.latest;
+
+  if (typeof latestVersion !== "string") {
+    throw new Error("Missing dist-tags.latest in react package metadata");
+  }
+
+  return latestVersion;
+}
+
+async function main() {
+  const latestVersion = await getLatestReactVersion();
+  const parsedLatest = parseSemver(latestVersion);
+  const peerRange = packageJson.peerDependencies?.react ?? "<missing>";
+  const upperBound = getReactSupportWindow(peerRange);
+  const supportedLineLabel = getSupportedLineLabel(upperBound);
+
+  if (compareSemver(parsedLatest, upperBound) < 0) {
+    console.log(`React ${latestVersion} is still within the supported line (${supportedLineLabel}).`);
+    return;
+  }
+
+  const failureLines = [
+    `React ${latestVersion} has been released on npm, but this repository only supports up to React ${supportedLineLabel}.`,
+    `A plain npm install of test-renderer is no longer safely constrained for the newest React release.`,
+    `Current peerDependencies.react: ${peerRange}`,
+    `Current derived React ceiling: <${formatSemver(upperBound)}`,
+    `Update the compatibility policy, add support for the new React line, and tighten the published peer dependency range before relying on latest again.`,
+  ];
+
+  throw new Error(failureLines.join("\n"));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/check-react-release-guard.mjs
+++ b/scripts/check-react-release-guard.mjs
@@ -1,5 +1,15 @@
 import packageJson from "../package.json" with { type: "json" };
 
+function getSupportedReactRange() {
+  const supportedReactRange = packageJson.testRenderer?.supportedReactRange;
+
+  if (typeof supportedReactRange !== "string" || supportedReactRange.trim() === "") {
+    throw new Error("package.json must define testRenderer.supportedReactRange");
+  }
+
+  return supportedReactRange;
+}
+
 function parseSemver(version) {
   const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
 
@@ -71,13 +81,11 @@ function parseExclusiveUpperBounds(range) {
   return upperBounds;
 }
 
-function getReactSupportWindow(range) {
+function getSupportedReactCeiling(range) {
   const upperBounds = parseExclusiveUpperBounds(range);
 
   if (upperBounds.length === 0) {
-    throw new Error(
-      `Could not derive a supported React ceiling from peerDependencies.react: ${range}`,
-    );
+    throw new Error(`Could not derive a supported React ceiling from range: ${range}`);
   }
 
   return upperBounds.reduce((lowest, candidate) =>
@@ -89,16 +97,16 @@ function formatSemver(version) {
   return `${version.major}.${version.minor}.${version.patch}`;
 }
 
-function getSupportedLineLabel(upperBound) {
+function getSupportedLinesLabel(upperBound) {
   if (upperBound.patch === 0 && upperBound.minor > 0) {
-    return `${upperBound.major}.${upperBound.minor - 1}.x`;
+    return `React ${upperBound.major}.0.x through ${upperBound.major}.${upperBound.minor - 1}.x`;
   }
 
   if (upperBound.minor === 0 && upperBound.patch === 0) {
-    return `${upperBound.major - 1}.x`;
+    return `React ${upperBound.major - 1}.x`;
   }
 
-  return `<${formatSemver(upperBound)}`;
+  return `React versions <${formatSemver(upperBound)}`;
 }
 
 async function getLatestReactVersion() {
@@ -130,20 +138,24 @@ async function main() {
   const latestVersion = await getLatestReactVersion();
   const parsedLatest = parseSemver(latestVersion);
   const peerRange = packageJson.peerDependencies?.react ?? "<missing>";
-  const upperBound = getReactSupportWindow(peerRange);
-  const supportedLineLabel = getSupportedLineLabel(upperBound);
+  const supportedReactRange = getSupportedReactRange();
+  const supportedReactCeiling = getSupportedReactCeiling(supportedReactRange);
+  const supportedLinesLabel = getSupportedLinesLabel(supportedReactCeiling);
 
-  if (compareSemver(parsedLatest, upperBound) < 0) {
-    console.log(`React ${latestVersion} is still within the supported line (${supportedLineLabel}).`);
+  if (compareSemver(parsedLatest, supportedReactCeiling) < 0) {
+    console.log(
+      `React ${latestVersion} is still within the supported window (${supportedLinesLabel}).`,
+    );
     return;
   }
 
   const failureLines = [
-    `React ${latestVersion} has been released on npm, but this repository only supports up to React ${supportedLineLabel}.`,
+    `React ${latestVersion} has been released on npm, but this repository currently supports only ${supportedLinesLabel}.`,
     `A plain npm install of test-renderer is no longer safely constrained for the newest React release.`,
     `Current peerDependencies.react: ${peerRange}`,
-    `Current derived React ceiling: <${formatSemver(upperBound)}`,
-    `Update the compatibility policy, add support for the new React line, and tighten the published peer dependency range before relying on latest again.`,
+    `Configured supportedReactRange: ${supportedReactRange}`,
+    `Current derived React ceiling: <${formatSemver(supportedReactCeiling)}`,
+    `Update testRenderer.supportedReactRange or tighten peerDependencies.react before relying on latest again.`,
   ];
 
   throw new Error(failureLines.join("\n"));

--- a/src/__tests__/react-release-guard.test.ts
+++ b/src/__tests__/react-release-guard.test.ts
@@ -1,0 +1,42 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, test } from "@jest/globals";
+
+const scriptPath = resolve(process.cwd(), "scripts/check-react-release-guard.mjs");
+
+describe("react release guard", () => {
+  test("accepts the latest release within the supported React line", () => {
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        REACT_RELEASE_GUARD_LATEST: "19.2.5",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "React 19.2.5 is still within the supported window (React 19.0.x through 19.2.x).",
+    );
+    expect(result.stderr).toBe("");
+  });
+
+  test("fails when the latest release moves past the supported React line", () => {
+    const result = spawnSync(process.execPath, [scriptPath], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        REACT_RELEASE_GUARD_LATEST: "19.3.0",
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "React 19.3.0 has been released on npm, but this repository currently supports only React 19.0.x through 19.2.x.",
+    );
+    expect(result.stderr).toContain("Current peerDependencies.react: ^19.0.0");
+    expect(result.stderr).toContain("Configured supportedReactRange: >=19.0.0 <19.3.0");
+    expect(result.stderr).toContain("Current derived React ceiling: <19.3.0");
+  });
+});

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -59,11 +59,9 @@ type HostContext = {
   config: ReconcilerConfig;
 };
 
-const nodeToInstanceMap = new WeakMap<object, Instance>();
-
-let currentUpdatePriority: number = NoEventPriority;
-
-const hostConfig: ReactReconciler.HostConfig<
+// Newer react-reconciler builds expect these event-related host config methods at runtime,
+// but the published @types/react-reconciler package may lag behind and omit them.
+type ExtendedHostConfig = ReactReconciler.HostConfig<
   Type,
   Props,
   Container,
@@ -77,7 +75,17 @@ const hostConfig: ReactReconciler.HostConfig<
   ChildSet,
   TimeoutHandle,
   NoTimeout
-> = {
+> & {
+  trackSchedulerEvent?: () => void;
+  resolveEventType?: () => null | string;
+  resolveEventTimeStamp?: () => number;
+};
+
+const nodeToInstanceMap = new WeakMap<object, Instance>();
+
+let currentUpdatePriority: number = NoEventPriority;
+
+const hostConfig: ExtendedHostConfig = {
   /**
    * The reconciler has two modes: mutation mode and persistent mode. You must specify one of them.
    *
@@ -283,6 +291,23 @@ const hostConfig: ReactReconciler.HostConfig<
     mark("reconciler/resolveUpdatePriority", { priority });
 
     return priority;
+  },
+
+  trackSchedulerEvent() {
+    mark("reconciler/trackSchedulerEvent");
+  },
+
+  resolveEventType(): null {
+    mark("reconciler/resolveEventType");
+
+    return null;
+  },
+
+  resolveEventTimeStamp(): number {
+    const timestamp = -1.1;
+    mark("reconciler/resolveEventTimeStamp", { timestamp });
+
+    return timestamp;
   },
 
   shouldAttemptEagerTransition() {


### PR DESCRIPTION
## Summary

Adds a release guard that fails once npm `react@latest` moves past the supported stable window defined in `testRenderer.supportedReactRange`, and updates automation to exercise that policy in nightly CI. It also adds the event-related host config hooks newer `react-reconciler` builds expect at runtime, updates ESLint handling for `.mjs` scripts, renames formatting scripts to `format` / `format:fix`, and covers the release guard with a dedicated Jest test.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Other (specify below)

Other: CI and release guard maintenance for React compatibility support.

## How Has This Been Tested?

- `bun run typecheck`
- `bun x jest --watchman=false`
- `bun run format`

## Checklist:

- [ ] Code follows style guidelines
- [x] Self-review completed
- [x] Code commented where necessary
- [x] Documentation updated
- [ ] No new warnings generated
- [x] Tests added/updated and passing
- [ ] Code coverage maintained/improved
- [ ] Dependent changes merged

## Additional Notes:

- `peerDependencies.react` remains broad as `^19.0.0`, while `testRenderer.supportedReactRange` explicitly records the tested stable support window as `>=19.0.0 <19.3.0`.
- Formatting scripts are renamed to `format` / `format:fix` while still using Prettier under the hood.
- PR CI now validates against `19.0.0` and `~19.0.0`, while nightly adds the React release guard and still keeps a dedicated React canary job.
- The release guard derives the supported React ceiling from `testRenderer.supportedReactRange`, checks npm metadata, and fails with an actionable message once the latest stable React release moves outside that configured window.
- `eslint.config.js` now disables typed lint rules for `js/mjs/cjs` files so the new release-guard script can live outside the TypeScript project graph.
- GitHub Actions were updated to `actions/checkout@v5` and `codecov-action@v5`, and the workflows set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`.
- The host config now defines `trackSchedulerEvent`, `resolveEventType`, and `resolveEventTimeStamp` so newer reconciler builds do not crash on missing runtime hooks even when `@types/react-reconciler` lags behind.
