### PR TITLE
feat: React 19.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Starting with `1.x`, `test-renderer` tracks preferred React 19 compatibility lin
 | `1.1.x`                 | `19.1`          | `~0.32.0`                  | Owner Stack support, CSS-selector-safe `useId()` format |
 | `1.2.x`                 | `19.2`          | `~0.33.0`                  | `<Activity />`, `useEffectEvent`                        |
 
-These examples are illustrative, not exhaustive. The `1.0.x` and `1.1.x` lines are current, and `1.2.x` is the next planned React 19 line. New React-minor-specific support lands on the matching preferred React / `react-reconciler` line for each `1.x` release, even though the package publishes a broad React 19 peer range.
+These examples are illustrative, not exhaustive. The `1.0.x`, `1.1.x`, and `1.2.x` lines are current compatibility lines. New React-minor-specific support lands on the matching preferred React / `react-reconciler` line for each `1.x` release, even though the package publishes a broad React 19 peer range.
 
 ## Test Output Tree
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "test-renderer",
       "dependencies": {
-        "@types/react-reconciler": "~0.32.0",
-        "react-reconciler": "~0.32.0",
+        "@types/react-reconciler": "~0.33.0",
+        "react-reconciler": "~0.33.0",
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -376,7 +376,7 @@
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
-    "@types/react-reconciler": ["@types/react-reconciler@0.32.3", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-cMi5ZrLG7UtbL7LTK6hq9w/EZIRk4Mf1Z5qHoI+qBh7/WkYkFXQ7gOto2yfUvPzF5ERMAhaXS5eTQ2SAnHjLzA=="],
+    "@types/react-reconciler": ["@types/react-reconciler@0.33.0", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g=="],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
@@ -1028,7 +1028,7 @@
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
-    "react-reconciler": ["react-reconciler@0.32.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ=="],
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -1062,7 +1062,7 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -138,7 +138,7 @@ When multiple `1.x` compatibility lines are live, direct `test-renderer` consume
 
 This keeps `npm` install flows predictable for users who consume `test-renderer` directly.
 
-During the rollout to later React 19 lines, `latest` may temporarily lag the highest planned compatibility line. Dist tags become more useful once there is more than one active `1.x` line.
+During rollouts to later React 19 lines, `latest` may temporarily lag the highest published compatibility line. Dist tags become more useful once there is more than one active `1.x` line.
 
 ## Summary
 
@@ -146,7 +146,7 @@ The recommended `test-renderer` 1.x scheme is:
 
 - `1.0.x` for React `19.0`
 - `1.1.x` for React `19.1`
-- `1.2.x` for React `19.2` when that line is published
+- `1.2.x` for React `19.2`
 
 With this scheme:
 

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "release": "release-it"
   },
   "dependencies": {
-    "@types/react-reconciler": "~0.32.0",
-    "react-reconciler": "~0.32.0"
+    "@types/react-reconciler": "~0.33.0",
+    "react-reconciler": "~0.33.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/__tests__/activity.test.tsx
+++ b/src/__tests__/activity.test.tsx
@@ -57,23 +57,25 @@ testGateReact19_2("Activity hides content while preserving child state", async (
   `);
 });
 
-testGateReact19_2("Activity keeps hidden instances in output with transformHiddenInstanceProps", async () => {
-  function Pane() {
-    return <div>Content</div>;
-  }
+testGateReact19_2(
+  "Activity keeps hidden instances in output with transformHiddenInstanceProps",
+  async () => {
+    function Pane() {
+      return <div>Content</div>;
+    }
 
-  function App({ mode }: { mode: "hidden" | "visible" }) {
-    return (
-      <Activity mode={mode}>
-        <Pane />
-      </Activity>
-    );
-  }
+    function App({ mode }: { mode: "hidden" | "visible" }) {
+      return (
+        <Activity mode={mode}>
+          <Pane />
+        </Activity>
+      );
+    }
 
-  const renderer = createRoot({ transformHiddenInstanceProps });
+    const renderer = createRoot({ transformHiddenInstanceProps });
 
-  await renderWithAct(renderer, <App mode="visible" />);
-  expect(renderer.container).toMatchInlineSnapshot(`
+    await renderWithAct(renderer, <App mode="visible" />);
+    expect(renderer.container).toMatchInlineSnapshot(`
     <>
       <div>
         Content
@@ -81,8 +83,8 @@ testGateReact19_2("Activity keeps hidden instances in output with transformHidde
     </>
   `);
 
-  await renderWithAct(renderer, <App mode="hidden" />);
-  expect(renderer.container).toMatchInlineSnapshot(`
+    await renderWithAct(renderer, <App mode="hidden" />);
+    expect(renderer.container).toMatchInlineSnapshot(`
     <>
       <div
         data-is-hidden={true}
@@ -92,12 +94,13 @@ testGateReact19_2("Activity keeps hidden instances in output with transformHidde
     </>
   `);
 
-  await renderWithAct(renderer, <App mode="visible" />);
-  expect(renderer.container).toMatchInlineSnapshot(`
+    await renderWithAct(renderer, <App mode="visible" />);
+    expect(renderer.container).toMatchInlineSnapshot(`
     <>
       <div>
         Content
       </div>
     </>
   `);
-});
+  },
+);

--- a/src/__tests__/activity.test.tsx
+++ b/src/__tests__/activity.test.tsx
@@ -1,0 +1,103 @@
+import { beforeEach, expect } from "@jest/globals";
+import { Activity, useState } from "react";
+
+import type { Props } from "../reconciler";
+import { createRoot } from "../renderer";
+import { testGateReact19_2 } from "../test-utils/react-version";
+import { renderWithAct } from "../test-utils/render";
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+const transformHiddenInstanceProps = ({ props }: { props: Props }) => ({
+  ...props,
+  "data-is-hidden": true,
+});
+
+testGateReact19_2("Activity hides content while preserving child state", async () => {
+  let nextStateId = 0;
+
+  function CounterPane() {
+    const [stateId] = useState(() => ++nextStateId);
+    return <div>Pane state: {stateId}</div>;
+  }
+
+  function App({ mode }: { mode: "hidden" | "visible" }) {
+    return (
+      <Activity mode={mode}>
+        <CounterPane />
+      </Activity>
+    );
+  }
+
+  const renderer = createRoot();
+
+  await renderWithAct(renderer, <App mode="visible" />);
+  expect(renderer.container).toMatchInlineSnapshot(`
+    <>
+      <div>
+        Pane state: 
+        1
+      </div>
+    </>
+  `);
+
+  await renderWithAct(renderer, <App mode="hidden" />);
+  expect(renderer.container).toMatchInlineSnapshot(`< />`);
+
+  await renderWithAct(renderer, <App mode="visible" />);
+  expect(renderer.container).toMatchInlineSnapshot(`
+    <>
+      <div>
+        Pane state: 
+        1
+      </div>
+    </>
+  `);
+});
+
+testGateReact19_2("Activity keeps hidden instances in output with transformHiddenInstanceProps", async () => {
+  function Pane() {
+    return <div>Content</div>;
+  }
+
+  function App({ mode }: { mode: "hidden" | "visible" }) {
+    return (
+      <Activity mode={mode}>
+        <Pane />
+      </Activity>
+    );
+  }
+
+  const renderer = createRoot({ transformHiddenInstanceProps });
+
+  await renderWithAct(renderer, <App mode="visible" />);
+  expect(renderer.container).toMatchInlineSnapshot(`
+    <>
+      <div>
+        Content
+      </div>
+    </>
+  `);
+
+  await renderWithAct(renderer, <App mode="hidden" />);
+  expect(renderer.container).toMatchInlineSnapshot(`
+    <>
+      <div
+        data-is-hidden={true}
+      >
+        Content
+      </div>
+    </>
+  `);
+
+  await renderWithAct(renderer, <App mode="visible" />);
+  expect(renderer.container).toMatchInlineSnapshot(`
+    <>
+      <div>
+        Content
+      </div>
+    </>
+  `);
+});

--- a/src/__tests__/effect-event.test.tsx
+++ b/src/__tests__/effect-event.test.tsx
@@ -9,29 +9,32 @@ beforeEach(() => {
   global.IS_REACT_ACT_ENVIRONMENT = true;
 });
 
-testGateReact19_2("useEffectEvent reads the latest value when an effect is triggered by another dependency", async () => {
-  const observedValues: string[] = [];
+testGateReact19_2(
+  "useEffectEvent reads the latest value when an effect is triggered by another dependency",
+  async () => {
+    const observedValues: string[] = [];
 
-  function Subscriber({ trigger, value }: { trigger: number; value: string }) {
-    const onEffectEvent = useEffectEvent(() => {
-      observedValues.push(value);
-    });
+    function Subscriber({ trigger, value }: { trigger: number; value: string }) {
+      const onEffectEvent = useEffectEvent(() => {
+        observedValues.push(value);
+      });
 
-    useEffect(() => {
-      onEffectEvent();
-    }, [trigger]);
+      useEffect(() => {
+        onEffectEvent();
+      }, [trigger]);
 
-    return <div>{value}</div>;
-  }
+      return <div>{value}</div>;
+    }
 
-  const renderer = createRoot();
+    const renderer = createRoot();
 
-  await renderWithAct(renderer, <Subscriber trigger={0} value="first" />);
-  expect(observedValues).toEqual(["first"]);
+    await renderWithAct(renderer, <Subscriber trigger={0} value="first" />);
+    expect(observedValues).toEqual(["first"]);
 
-  await renderWithAct(renderer, <Subscriber trigger={0} value="second" />);
-  expect(observedValues).toEqual(["first"]);
+    await renderWithAct(renderer, <Subscriber trigger={0} value="second" />);
+    expect(observedValues).toEqual(["first"]);
 
-  await renderWithAct(renderer, <Subscriber trigger={1} value="second" />);
-  expect(observedValues).toEqual(["first", "second"]);
-});
+    await renderWithAct(renderer, <Subscriber trigger={1} value="second" />);
+    expect(observedValues).toEqual(["first", "second"]);
+  },
+);

--- a/src/__tests__/effect-event.test.tsx
+++ b/src/__tests__/effect-event.test.tsx
@@ -1,0 +1,37 @@
+import { beforeEach, expect } from "@jest/globals";
+import { useEffect, useEffectEvent } from "react";
+
+import { createRoot } from "../renderer";
+import { testGateReact19_2 } from "../test-utils/react-version";
+import { renderWithAct } from "../test-utils/render";
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+testGateReact19_2("useEffectEvent reads the latest value when an effect is triggered by another dependency", async () => {
+  const observedValues: string[] = [];
+
+  function Subscriber({ trigger, value }: { trigger: number; value: string }) {
+    const onEffectEvent = useEffectEvent(() => {
+      observedValues.push(value);
+    });
+
+    useEffect(() => {
+      onEffectEvent();
+    }, [trigger]);
+
+    return <div>{value}</div>;
+  }
+
+  const renderer = createRoot();
+
+  await renderWithAct(renderer, <Subscriber trigger={0} value="first" />);
+  expect(observedValues).toEqual(["first"]);
+
+  await renderWithAct(renderer, <Subscriber trigger={0} value="second" />);
+  expect(observedValues).toEqual(["first"]);
+
+  await renderWithAct(renderer, <Subscriber trigger={1} value="second" />);
+  expect(observedValues).toEqual(["first", "second"]);
+});

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -115,7 +115,6 @@ export function createRoot(options?: RootOptions): Root {
     options?.onCaughtError ?? defaultOnCaughtError,
     options?.onRecoverableError ?? defaultOnRecoverableError,
     defaultOnDefaultTransitionIndicator,
-    null, // transitionCallbacks
   );
 
   measureEnd("createRoot");

--- a/src/test-utils/react-version.ts
+++ b/src/test-utils/react-version.ts
@@ -1,0 +1,21 @@
+import { test } from "@jest/globals";
+import React from "react";
+
+function isReactMinorOrNewer(targetMinor: number): boolean {
+  const match = /^(\d+)\.(\d+)/.exec(React.version);
+
+  if (!match) {
+    return false;
+  }
+
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+
+  if (major !== 19) {
+    return major > 19;
+  }
+
+  return minor >= targetMinor;
+}
+
+export const testGateReact19_2 = isReactMinorOrNewer(2) ? test : test.skip;


### PR DESCRIPTION
## Summary

Prepare React 19.2 support by moving `test-renderer` to the preferred `react-reconciler ~0.33.0` line, aligning the 19.2 `createContainer` call shape, and adding gated coverage for `React.Activity` and `useEffectEvent`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Other (specify below)

Other: React 19.2 compatibility line update

## How Has This Been Tested?

- `bun run typecheck`
- `bunx jest --watchman=false src/__tests__/activity.test.tsx`
- `bunx jest --watchman=false src/__tests__/effect-event.test.tsx`
- `bun run build`
- `bunx jest --watchman=false`
- `bun run lint`

## Checklist:

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Code commented where necessary
- [x] Documentation updated
- [x] No new warnings generated
- [x] Tests added/updated and passing
- [x] Code coverage maintained/improved
- [ ] Dependent changes merged

## Additional Notes:

- `react-reconciler` and `@types/react-reconciler` now target the `0.33.x` line, which is the preferred reconciler line for `test-renderer` `1.2.x`.
- React 19.2 removes the extra `transitionCallbacks` argument from the `createContainer` call shape used on the 19.1 line.
- Added `testGateReact19_2` plus focused `Activity` and `useEffectEvent` tests for the main React 19.2 feature additions relevant to `test-renderer`.
- `README.md` and `docs/versioning.md` now treat `1.2.x` as a current compatibility line instead of a planned one.
