### PR TITLE
fix: render/unmount synchronously so a leaked act scope can't strand later renders

### DIFF
--- a/src/__tests__/render-nested-act.test.tsx
+++ b/src/__tests__/render-nested-act.test.tsx
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { createElement } from "react";
+
+import { createRoot } from "../renderer";
+import { act, renderWithAct, unmountWithAct } from "../test-utils/render";
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+/**
+ * Regression test: `render()` (and `unmount()`) must commit synchronously even
+ * when React's module-level `actScopeDepth` is already above zero — i.e. when the
+ * render runs inside what `act()` treats as a *nested* scope and therefore does
+ * NOT flush its work queue.
+ *
+ * Why this matters in real suites: React's `act()` only flushes its internal work
+ * queue when it is the OUTERMOST act (`prevActScopeDepth === 0`). A single
+ * not-yet-settled `act()` call elsewhere in the run leaves `actScopeDepth`
+ * elevated for every later `act()`. This happens routinely with
+ * `@testing-library/react-native` v14: its `afterEach` auto-cleanup unmounts
+ * inside `act()`, and many RN jest setups additionally wrap the global timers in
+ * `act()` (to silence "not wrapped in act(...)" warnings). The net effect was that
+ * only the FIRST test in a file rendered — every subsequent `render()`/
+ * `renderHook()` committed an empty tree (`toJSON() === null`).
+ *
+ * Root cause: `render()` used `updateContainer` (a Default-lane update on a
+ * ConcurrentRoot), which only commits when the outermost `act()` flushes its
+ * queue. Rendering at Sync lane and flushing immediately makes the commit
+ * independent of the ambient act scope — the same thing `react-test-renderer`
+ * gets for free by rendering RN trees on a LegacyRoot (Sync lanes).
+ */
+describe("render/unmount commit synchronously regardless of the ambient act() scope", () => {
+  const Probe = () => createElement("View", { testID: "root" }, createElement("Text", null, "hi"));
+
+  const rootOptions = { textComponentTypes: ["Text"], publicTextComponentTypes: ["Text"] };
+
+  // Three sequential renders on fresh roots, each performed while an OUTER act()
+  // scope is still open (so the render's own act() is nested and never flushes).
+  // Before the fix, only a render at the outermost scope committed, so these
+  // assertions saw an empty tree.
+  test.each(["first", "second", "third"])(
+    "%s render inside a nested act() is visible immediately",
+    async () => {
+      await act(async () => {
+        const root = createRoot(rootOptions);
+        await renderWithAct(root, <Probe />);
+
+        const json = root.container.toJSON();
+        expect(json).not.toBeNull();
+        expect(json?.children.length ?? 0).toBeGreaterThan(0);
+      });
+    },
+  );
+
+  test("unmount inside a nested act() actually tears the tree down", async () => {
+    await act(async () => {
+      const root = createRoot(rootOptions);
+      await renderWithAct(root, <Probe />);
+      expect(root.container.children.length).toBe(1);
+
+      await unmountWithAct(root);
+      // `unmount()` nulls the container, so accessing it must throw rather than
+      // silently no-op — proving the unmount committed, not just got queued.
+      expect(() => root.container).toThrow("Cannot access .container on unmounted test renderer");
+    });
+  });
+});

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -129,7 +129,14 @@ export function createRoot(options?: RootOptions): Root {
     try {
       assertValidRootElement(element);
       elementType = String(element.type);
-      TestReconciler.updateContainer(element, containerFiber, null, null);
+      // Render at Sync lane and flush immediately, rather than scheduling a
+      // Default-lane update that only commits when React's outermost `act()`
+      // flushes its work queue. A single not-yet-settled `act()` elsewhere in the
+      // run (RNTL's afterEach cleanup unmount, a timer wrapped in `act()`, ...)
+      // leaves `actScopeDepth > 0`, making every later render's `act()` nested and
+      // non-flushing — which committed an empty tree. See render-nested-act.test.
+      TestReconciler.updateContainerSync(element, containerFiber, null, null);
+      TestReconciler.flushSyncWork();
     } finally {
       measureEnd("render", { elementType });
     }
@@ -142,7 +149,11 @@ export function createRoot(options?: RootOptions): Root {
 
     measureStart("unmount");
     try {
-      TestReconciler.updateContainer(null, containerFiber, null, null);
+      // Unmount synchronously for the same reason `render` does — so cleanup
+      // actually tears the tree down within the call instead of leaving a
+      // Default-lane update pending on an act scope that may never flush.
+      TestReconciler.updateContainerSync(null, containerFiber, null, null);
+      TestReconciler.flushSyncWork();
     } finally {
       measureEnd("unmount");
     }


### PR DESCRIPTION
Fixes #53.

## Summary

`render()` scheduled a **Default-lane** update on the ConcurrentRoot created in `createRoot`. A Default-lane update inside `act()` only commits when React flushes the act work queue, and React's `act()` flushes that queue **only when it is the outermost act** (`prevActScopeDepth === 0`). `actScopeDepth` is module-level in the `react` package and is only restored when an `act()`'s thenable is awaited, so a single **not-yet-settled `act()`** in the run — RNTL v14's `afterEach` cleanup unmount, or a jest setup that wraps the global timers in `act()` — leaves it above zero. From then on every `await act(() => root.render(...))` is treated as nested and never flushes, so only the first test in a file rendered and every later `render()` / `renderHook()` committed an empty tree (`toJSON() === null`).

This changes `render()` and `unmount()` to commit **synchronously** — Sync lane + immediate flush (`updateContainerSync` + `flushSyncWork`, the same pair the reconciler uses for Fast Refresh in `scheduleRoot`). The commit no longer depends on the ambient act scope, mirroring how `react-test-renderer` renders React Native trees on a LegacyRoot.

```diff
-      TestReconciler.updateContainer(element, containerFiber, null, null);
+      TestReconciler.updateContainerSync(element, containerFiber, null, null);
+      TestReconciler.flushSyncWork();
```

## Type of change

- [x] Bug fix

## How Has This Been Tested?

- **New regression test** `src/__tests__/render-nested-act.test.tsx` (renders/unmounts inside a nested act scope): **fails on `main`, passes with this change**, no act warnings.
- **Full `test-renderer` suite**: `bun run validate` green — 52 tests (Suspense / Activity / effect-event unaffected), typecheck, lint, and `oxfmt` all clean.
- **`@testing-library/react-native` v14 suite** with this build linked in: **83 suites / 795 tests green** (no regression).
- **Real-world repro** (a production Expo/RN app: jest setup that wraps timers in `act()` + RNTL v14 **default** auto-cleanup, no `RNTL_SKIP_AUTO_CLEANUP`): the failing multi-test files now pass — a 12-test sanity file mixing `render` + `renderHook` + `rerender` + `unmount` + `useEffect` is green (was: only the first test rendered).
- **Parity with `react-test-renderer`**: verified it renders the same trees in normal flow; the fixed renderer is strictly more robust in the nested-act edge.

## Checklist:

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Code commented where necessary
- [ ] Documentation updated (n/a)
- [x] No new warnings generated
- [x] Tests added/updated and passing
- [x] Code coverage maintained/improved

## Additional Notes:

Ruled-out alternatives (all verified not to fix it):

1. A fresh `ReactReconciler(hostConfig)` per `createRoot` — react-reconciler's work-loop state is module-level, shared across reconciler instances.
2. `LegacyRoot` instead of `ConcurrentRoot` — a Sync-lane update scheduled *inside* `act()` still routes through the act queue (`ensureRootIsScheduled` diverts when `actQueue !== null`), so it still relies on the outermost act flushing. This fix works because `flushSyncWork()` flushes via `flushSyncWorkAcrossRoots_impl` directly, bypassing the act queue.
3. Resetting the host config's `currentUpdatePriority` after unmount — no effect.
4. Removing the `act()` wrapper on the cleanup unmount — no effect.

Scope: this covers the renderer's imperative APIs (`render`/`rerender`/`unmount`, and therefore `renderHook`). Event-driven updates via `fireEvent` that a leaked act scope also strands go through RNTL's own `act()`, not `test-renderer`'s API, so they're outside what a renderer change can reach — the real remedy there is not leaking the act scope in the first place.
